### PR TITLE
Add Recent Checkpoint & Add to MainNetDNSSeeds

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -41,6 +41,7 @@ namespace Checkpoints
 	( 338643, uint256("0xdd79a4b1ac2a91d9666d97a2654ee826c84e55495665bacaac2b9a953616f8d6"))
 	( 406644, uint256("0xc0f29fe22936216e6a90a4178967ba8ffa9ad78930aa1a369a6fc727a3d2f8e5"))
         ( 845000, uint256("0xa32d61133e22687a63c0c2769552a851a484b030cda02f8a1def5a506d368e33"))
+	( 966000, uint256("0xa504a4fc3b19e8c7ad1d0800df820de723472678faef5ce10518c56b9d3cd8ff"))
 	;
     static const CCheckpointData data = {
         &mapCheckpoints,

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1193,7 +1193,9 @@ void MapPort(bool)
 static const char *strMainNetDNSSeed[][2] = {
 	{"blakecoin.org", "blakecoin.org"},
 	{"blakecoin.com", "blakecoin.com"},
-        {"178.62.221.227", "178.62.221.227"},
+	{"bbtc.electroncoin.org", "bbtc.electroncoin.org"},
+	{"bbtc2.electroncoin.org", "bbtc2.electroncoin.org"},
+	{"178.62.221.227", "178.62.221.227"},
 	{"165.227.200.255", "165.227.200.255"},
 	{"67.205.187.161", "67.205.187.161"},
 	{NULL, NULL}


### PR DESCRIPTION
This pull request will add a recent checkpoint and add bbtc.electroncoin.org & bbtc2.electroncoin.org to MainNetDNSSeeds.