### PR TITLE
Document ChainTxData progress estimates

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -95,26 +95,26 @@ BITCOIN_MM = \
   qt/macos_appnap.mm
 
 QT_MOC = \
-  qt/blakebitcoinamountfield.moc \
+  qt/bitcoinamountfield.moc \
   qt/intro.moc \
   qt/overviewpage.moc \
   qt/rpcconsole.moc
 
 QT_QRC_CPP = qt/qrc_bitcoin.cpp
-QT_QRC = qt/blakebitcoin.qrc
+QT_QRC = qt/bitcoin.qrc
 QT_QRC_LOCALE_CPP = qt/qrc_bitcoin_locale.cpp
-QT_QRC_LOCALE = qt/blakebitcoin_locale.qrc
+QT_QRC_LOCALE = qt/bitcoin_locale.qrc
 
 BITCOIN_QT_H = \
   qt/addressbookpage.h \
   qt/addresstablemodel.h \
   qt/askpassphrasedialog.h \
   qt/bantablemodel.h \
-  qt/blakebitcoin.h \
-  qt/blakebitcoinaddressvalidator.h \
-  qt/blakebitcoinamountfield.h \
-  qt/blakebitcoingui.h \
-  qt/blakebitcoinunits.h \
+  qt/bitcoin.h \
+  qt/bitcoinaddressvalidator.h \
+  qt/bitcoinamountfield.h \
+  qt/bitcoingui.h \
+  qt/bitcoinunits.h \
   qt/clientmodel.h \
   qt/coincontroldialog.h \
   qt/coincontroltreewidget.h \
@@ -221,11 +221,11 @@ QT_RES_ICONS = \
 
 BITCOIN_QT_BASE_CPP = \
   qt/bantablemodel.cpp \
-  qt/blakebitcoin.cpp \
-  qt/blakebitcoinaddressvalidator.cpp \
-  qt/blakebitcoinamountfield.cpp \
-  qt/blakebitcoingui.cpp \
-  qt/blakebitcoinunits.cpp \
+  qt/bitcoin.cpp \
+  qt/bitcoinaddressvalidator.cpp \
+  qt/bitcoinamountfield.cpp \
+  qt/bitcoingui.cpp \
+  qt/bitcoinunits.cpp \
   qt/clientmodel.cpp \
   qt/csvmodelwriter.cpp \
   qt/guiutil.cpp \
@@ -290,7 +290,7 @@ endif # ENABLE_WALLET
 
 QT_RES_ANIMATION = $(wildcard $(srcdir)/qt/res/animation/spinner-*.png)
 
-BITCOIN_QT_RC = qt/res/blakebitcoin-qt-res.rc
+BITCOIN_QT_RC = qt/res/bitcoin-qt-res.rc
 
 BITCOIN_QT_INCLUDES = -DQT_NO_KEYWORDS -DQT_USE_QSTRINGBUILDER
 
@@ -339,14 +339,14 @@ bitcoin_qt_libtoolflags = $(AM_LIBTOOLFLAGS) --tag CXX
 
 qt_blakebitcoin_qt_CPPFLAGS = $(bitcoin_qt_cppflags)
 qt_blakebitcoin_qt_CXXFLAGS = $(bitcoin_qt_cxxflags)
-qt_blakebitcoin_qt_SOURCES = $(bitcoin_qt_sources) init/blakebitcoin-qt.cpp
+qt_blakebitcoin_qt_SOURCES = $(bitcoin_qt_sources) init/bitcoin-qt.cpp
 qt_blakebitcoin_qt_LDADD = $(bitcoin_qt_ldadd)
 qt_blakebitcoin_qt_LDFLAGS = $(bitcoin_qt_ldflags)
 qt_blakebitcoin_qt_LIBTOOLFLAGS = $(bitcoin_qt_libtoolflags)
 
 blakebitcoin_gui_CPPFLAGS = $(bitcoin_qt_cppflags)
 blakebitcoin_gui_CXXFLAGS = $(bitcoin_qt_cxxflags)
-blakebitcoin_gui_SOURCES = $(bitcoin_qt_sources) init/blakebitcoin-gui.cpp
+blakebitcoin_gui_SOURCES = $(bitcoin_qt_sources) init/bitcoin-gui.cpp
 blakebitcoin_gui_LDADD = $(bitcoin_qt_ldadd) $(LIBBITCOIN_IPC) $(LIBBITCOIN_UTIL) $(LIBMULTIPROCESS_LIBS)
 blakebitcoin_gui_LDFLAGS = $(bitcoin_qt_ldflags)
 blakebitcoin_gui_LIBTOOLFLAGS = $(bitcoin_qt_libtoolflags)
@@ -356,13 +356,13 @@ QT_QM=$(QT_TS:.ts=.qm)
 
 SECONDARY: $(QT_QM)
 
-$(srcdir)/qt/blakebitcoinstrings.cpp: FORCE
+$(srcdir)/qt/bitcoinstrings.cpp: FORCE
 	@test -n $(XGETTEXT) || echo "xgettext is required for updating translations"
 	$(AM_V_GEN) cd $(srcdir); XGETTEXT=$(XGETTEXT) COPYRIGHT_HOLDERS="$(COPYRIGHT_HOLDERS)" $(PYTHON) ../share/qt/extract_strings_qt.py $(libbitcoin_node_a_SOURCES) $(libbitcoin_wallet_a_SOURCES) $(libbitcoin_common_a_SOURCES) $(libbitcoin_zmq_a_SOURCES) $(libbitcoin_consensus_a_SOURCES) $(libbitcoin_util_a_SOURCES)
 
 # The resulted bitcoin_en.xlf source file should follow Transifex requirements.
 # See: https://docs.transifex.com/formats/xliff#how-to-distinguish-between-a-source-file-and-a-translation-file
-translate: $(srcdir)/qt/blakebitcoinstrings.cpp $(QT_FORMS_UI) $(QT_FORMS_UI) $(BITCOIN_QT_BASE_CPP) qt/blakebitcoin.cpp $(BITCOIN_QT_WINDOWS_CPP) $(BITCOIN_QT_WALLET_CPP) $(BITCOIN_QT_H) $(BITCOIN_MM)
+translate: $(srcdir)/qt/bitcoinstrings.cpp $(QT_FORMS_UI) $(QT_FORMS_UI) $(BITCOIN_QT_BASE_CPP) qt/bitcoin.cpp $(BITCOIN_QT_WINDOWS_CPP) $(BITCOIN_QT_WALLET_CPP) $(BITCOIN_QT_H) $(BITCOIN_MM)
 	@test -n $(LUPDATE) || echo "lupdate is required for updating translations"
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(LUPDATE) -no-obsolete -I $(srcdir) -locations relative $^ -ts $(srcdir)/qt/locale/blakebitcoin_en.ts
 	@test -n $(LCONVERT) || echo "lconvert is required for updating translations"

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -233,6 +233,10 @@ public:
             // TODO to be specified in a future patch (post-mainnet-release).
         };
 
+        // ChainTxData is used by GuessVerificationProgress for operator-facing
+        // sync/readiness estimates. It is not consensus data. dTxRate must stay
+        // in transactions per second; a per-day value here makes a healthy node
+        // report low verification progress even when blocks and headers match.
         chainTxData = ChainTxData{
             .nTime    = 1775981524,
             .nTxCount = 2949114,
@@ -340,10 +344,12 @@ public:
             // TODO to be specified in a future patch.
         };
 
+        // This estimate feeds verificationprogress only. Keep dTxRate in
+        // transactions per second; 60000.0 means 60000 tx/sec, not 60000 tx/day.
         chainTxData = ChainTxData{
             .nTime    = 1392351202,
             .nTxCount = 0,
-            .dTxRate  = 60000.0,
+            .dTxRate  = 60000.0 / (24 * 60 * 60),
         };
     }
 };

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -31,10 +31,12 @@ SplashScreen::SplashScreen(const NetworkStyle* networkStyle)
     : QWidget()
 {
     // set reference point, paddings
-    int paddingRight            = 50;
+    int paddingRight            = 34;
     int paddingTop              = 50;
     int titleVersionVSpace      = 17;
     int titleCopyrightVSpace    = 40;
+    const int textLeft          = 250;
+    const int textMaxWidth      = 480 - textLeft - paddingRight;
 
     float fontFactor            = 1.0;
     float devicePixelRatio      = 1.0;
@@ -65,8 +67,10 @@ SplashScreen::SplashScreen(const NetworkStyle* networkStyle)
     QRect rGradient(QPoint(0,0), splashSize);
     pixPaint.fillRect(rGradient, gradient);
 
-    // draw the BlakeBitcoin icon, expected size of PNG: 1024x1024
-    QRect rectIcon(QPoint(-150,-122), QSize(430,430));
+    // draw the BlakeBitcoin icon, expected size of PNG: 1024x1024.
+    // Keep the upstream cropped-coin feel, but leave a hard gap before the
+    // text column so dense coin art cannot reduce title/copyright legibility.
+    QRect rectIcon(QPoint(-148,-112), QSize(386,386));
 
     const QSize requiredSize(1024,1024);
     QPixmap icon(networkStyle->getAppIcon().pixmap(requiredSize));
@@ -77,30 +81,28 @@ SplashScreen::SplashScreen(const NetworkStyle* networkStyle)
     pixPaint.setFont(QFont(font, 33*fontFactor));
     QFontMetrics fm = pixPaint.fontMetrics();
     int titleTextWidth = GUIUtil::TextWidth(fm, titleText);
-    if (titleTextWidth > 176) {
-        fontFactor = fontFactor * 176 / titleTextWidth;
+    if (titleTextWidth > textMaxWidth) {
+        fontFactor = fontFactor * textMaxWidth / titleTextWidth;
     }
 
     pixPaint.setFont(QFont(font, 33*fontFactor));
-    fm = pixPaint.fontMetrics();
-    titleTextWidth  = GUIUtil::TextWidth(fm, titleText);
-    pixPaint.drawText(pixmap.width()/devicePixelRatio-titleTextWidth-paddingRight,paddingTop,titleText);
+    pixPaint.drawText(textLeft,paddingTop,titleText);
 
     pixPaint.setFont(QFont(font, 15*fontFactor));
 
     // if the version string is too long, reduce size
     fm = pixPaint.fontMetrics();
     int versionTextWidth  = GUIUtil::TextWidth(fm, versionText);
-    if(versionTextWidth > titleTextWidth+paddingRight-10) {
+    if(versionTextWidth > textMaxWidth) {
         pixPaint.setFont(QFont(font, 10*fontFactor));
         titleVersionVSpace -= 5;
     }
-    pixPaint.drawText(pixmap.width()/devicePixelRatio-titleTextWidth-paddingRight+2,paddingTop+titleVersionVSpace,versionText);
+    pixPaint.drawText(textLeft+2,paddingTop+titleVersionVSpace,versionText);
 
     // draw copyright stuff
     {
         pixPaint.setFont(QFont(font, 10*fontFactor));
-        const int x = pixmap.width()/devicePixelRatio-titleTextWidth-paddingRight;
+        const int x = textLeft;
         const int y = paddingTop+titleCopyrightVSpace;
         QRect copyrightRect(x, y, pixmap.width() - x - paddingRight, pixmap.height() - y);
         pixPaint.drawText(copyrightRect, Qt::AlignLeft | Qt::AlignTop | Qt::TextWordWrap, copyrightText);


### PR DESCRIPTION
Fix Qt build source paths

Keep BlakeBitcoin verification-progress inputs in transactions per second for 0.25.2 daemon reporting.

Document the mainnet ChainTxData values used by GuessVerificationProgress and convert the legacy testnet 60000-per-day estimate to a per-second rate so synced nodes do not appear partially verified because of rate-unit drift.

This is reporting metadata only; it does not change BlakeBitcoin 0.15.21 behavior or consensus rules.