### PR TITLE
Fix AuxPoW version gating and record SegWit height

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ builds.
 
 ## Mainnet Consensus Changes In 0.25.2
 
-**Mainnet SegWit status: BlakeBitcoin 0.15.21 has not yet reached mainnet SegWit ACTIVE.**
+**Mainnet SegWit status: BlakeBitcoin 0.25.2 inherits the recorded 0.15.21 SegWit ACTIVE height `2564352`.**
 
-This 0.25.2 line therefore leaves SegWit unburied at the placeholder height
-and does not create a second signaling window. The other cleanup BIPs and
-Taproot are assigned to the later aux-coin rollout window, with BBTC-specific
-heights derived from its 150-second block spacing.
+This 0.25.2 line buries SegWit at height `2564352` and does not create a
+second signaling window. The other cleanup BIPs and Taproot are assigned to
+the later aux-coin rollout window, with BBTC-specific heights derived from its
+150-second block spacing.
 
 Pools and miners should use the daemon-provided AuxPoW block-template version.
 Do not manually rewrite version bits.
 
 | Rule set | Mainnet policy in BlakeBitcoin 0.25.2 |
 |---|---|
-| SegWit (`BIP141` / `BIP143` / `BIP147`) | Pending; keep `SegwitHeight = 100000000` until the actual 0.15.21 ACTIVE height is known. |
+| SegWit (`BIP141` / `BIP143` / `BIP147`) | Buried at `SegwitHeight = 2564352`; inherited from the 0.15.21 BIP9 activation result and not re-signaled in 0.25.2. |
 | `BIP34` coinbase height | Height activation at `2572228`; `BIP34Hash = uint256{}`. |
 | `BIP65` / CLTV | Height activation at `2572228`; required for standard CLTV atomic-swap refunds. |
 | `BIP66` / strict DER | Height activation at `2572228`. |
 | Taproot (`BIP340` / `BIP341` / `BIP342`) | BIP9 deployment bit `2`, start `1782871200` (`2026-07-01 02:00:00 UTC`), timeout `1814407200` (`2027-07-01 02:00:00 UTC`), minimum activation height `2576260`. |
 
 Only Taproot is a future BIP9-signaled deployment in 0.25.2. `BIP34`,
-`BIP65`, `BIP66`, and the pending SegWit burial are height rules.
+`BIP65`, `BIP66`, and buried SegWit are height rules.
 BlakeBitcoin Core computes the correct BIP9 top bits, Taproot bit `2`, AuxPoW
 flag, and BlakeBitcoin chain-ID bits in block templates.
 
@@ -73,9 +73,9 @@ family. It is a peer-to-peer digital currency with no central authority.
 
 ## Network Activation Notes
 
-BBTC SegWit remains pending on the 0.15.21 mainnet line. Do not replace
-`SegwitHeight = 100000000` in 0.25.2 until the released 0.15.21 deployment
-reaches ACTIVE and the actual activation height is recorded.
+BBTC SegWit is treated as inherited mainnet history in 0.25.2. The buried
+height is `SegwitHeight = 2564352`, matching the 0.15.21 BIP9 ACTIVE-height
+rollout math.
 
 Testnet is treated as a 0.25.2 feature-test/reset network. SegWit, BIP34,
 BIP65/CLTV, BIP66, and Taproot are active from height `1` on testnet so

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -98,8 +98,8 @@ public:
         // and Photon (perpetual difficulty-aware reward). See
         // coin-source-of-truth.md "BlakeBitcoin (BBTC)" Subsidy line.
         consensus.nSubsidyHalvingInterval = 210000;
-        // BBTC 0.25.2 keeps SegWit pending until the 0.15.21 line reaches ACTIVE,
-        // but schedules the post-rebase cleanup BIPs in the later family window.
+        // BBTC 0.25.2 buries the recorded 0.15.21 SegWit ACTIVE height and
+        // schedules the post-rebase cleanup BIPs in the later family window.
         consensus.BIP34Height = 2572228;
         consensus.BIP34Hash = uint256{};
         consensus.BIP65Height = 2572228;
@@ -108,16 +108,10 @@ public:
         // primitive. ALWAYS_ACTIVE from genesis on Blakestream family per
         // coin-source-of-truth.md "Common rules". Do NOT change.
         consensus.CSVHeight = 1;
-        // TODO(blakestream-25.2-activation): SegWit (BIP141/143/147) — atomic-swap
-        // anchor (P2WSH HTLC). Activates on BBTC-0.15.21 mainnet via BIP9 (start
-        // May 11 2026, one week behind the parent). When 0.15.21 SegWit reaches
-        // LOCKED_IN -> ACTIVE on mainnet, capture the activation height with
-        // `blakebitcoin-cli getblockchaininfo` (read "softforks.segwit.height" or
-        // scan the block index where IsBIP9Active(SEGWIT) flipped) and replace the
-        // placeholder 100000000 here with that height. Once captured and shipped
-        // on 0.25.2, this is a BURIED activation height: 0.25.2 inherits already-
-        // active SegWit at this height, never re-signals.
-        consensus.SegwitHeight = 100000000;
+        // SegWit (BIP141/143/147) — atomic-swap anchor (P2WSH HTLC). BBTC
+        // 0.25.2 inherits the 0.15.21 BIP9 activation result as a buried height
+        // and does not create a second SegWit signaling window.
+        consensus.SegwitHeight = 2564352;
         consensus.MinBIP9WarningHeight = 0;
         // BBTC-0.15.21 powLimit (from src/chainparams.cpp:87) is the wider mask
         // ~uint256(0)>>24 = 0x000000FF...FF (3 bytes zero, 29 bytes ff). NOT the

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2177,6 +2177,17 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                                           pindex->nHeight < params.GetConsensus().BIP34Height;
     bool fEnforceBIP30 = !legacy_mainnet_pre_bip34 && !IsBIP30Repeat(*pindex);
 
+    // NOTE (BlakeBitcoin): the comment block below is inherited verbatim from
+    // Bitcoin Core and describes *Bitcoin's* history — the "BIP34 height of
+    // 227,931" and the out-of-sequence indicated heights (209,921 / 490,897 /
+    // 1,983,702) are Bitcoin's, not BlakeBitcoin's. BBTC's actual rule is set
+    // above: BIP30 is disabled on mainnet below BIP34Height (2572228) via
+    // legacy_mainnet_pre_bip34 and enforced strictly at/after it. The
+    // IsBIP30Repeat/IsBIP30Unspendable lists are BBTC-specific legacy 0.15.21
+    // duplicate coinbases. The inherited text is kept for provenance; do not act
+    // on its Bitcoin-specific heights.
+    //
+    // [Bitcoin Core, for reference]
     // Once BIP34 activated it was not possible to create new duplicate coinbases and thus other than starting
     // with the 2 existing duplicate coinbase pairs, not possible to create overwriting txs.  But by the
     // time BIP34 activated, in each of the existing pairs the duplicate coinbase had overwritten the first
@@ -3760,10 +3771,16 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
         return state.Invalid(BlockValidationResult::BLOCK_TIME_FUTURE, "time-too-new", "block timestamp too far in the future");
     }
 
-    // Reject blocks with outdated version
-    if ((block.nVersion < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
-        (block.nVersion < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
-        (block.nVersion < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
+    // Reject blocks with outdated version. Gate on the BASE version: this is an
+    // AuxPoW chain, so the chain-id (and auxpow flag) live in the high bits of
+    // nVersion and would otherwise inflate it above the 2/3/4 thresholds, making
+    // the check a no-op. GetBaseVersion() reads the version with those high bits
+    // masked off (the header's nVersion is unchanged), so the comparison sees the
+    // real base version (Namecoin/AuxPoW convention). Diagnostics below still
+    // print the raw on-the-wire nVersion.
+    if ((block.GetBaseVersion() < 2 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_HEIGHTINCB)) ||
+        (block.GetBaseVersion() < 3 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_DERSIG)) ||
+        (block.GetBaseVersion() < 4 && DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_CLTV))) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
     }


### PR DESCRIPTION
Version gate compares GetBaseVersion() so AuxPoW chain-id bits can't defeat BIP34/65/66. Plus inherited-BIP30 comment annotation.

Bury BlakeBitcoin mainnet SegWit at height 2564352, inheriting the recorded 0.15.21 BIP9 activation result without creating a second signaling window.

Update README activation notes so operators see SegWit as inherited mainnet history alongside the later BIP34/BIP65/BIP66 and Taproot rollout heights.