### PR TITLE
Start versionbit warnings at buried SegWit height

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -112,7 +112,9 @@ public:
         // 0.25.2 inherits the 0.15.21 BIP9 activation result as a buried height
         // and does not create a second SegWit signaling window.
         consensus.SegwitHeight = 2564352;
-        consensus.MinBIP9WarningHeight = 0;
+        // Historical miners set SegWit/versionbits before burial. Only warn
+        // on post-burial unknown versionbits.
+        consensus.MinBIP9WarningHeight = 2564352;
         // BBTC-0.15.21 powLimit (from src/chainparams.cpp:87) is the wider mask
         // ~uint256(0)>>24 = 0x000000FF...FF (3 bytes zero, 29 bytes ff). NOT the
         // narrower 0x000000FFFF000... used elsewhere in the family. This is the


### PR DESCRIPTION
Set BlakeBitcoin mainnet MinBIP9WarningHeight to the buried SegWit activation height so historical SegWit/versionbits signaling does not trigger the unknown-new-rules warning after upgrade.

Keep future post-burial unknown versionbit warnings enabled.