### PR TITLE
Add mainnet AssumeUTXO snapshot metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ BBTC SegWit is treated as inherited mainnet history in 0.25.2. The buried
 height is `SegwitHeight = 2564352`, matching the 0.15.21 BIP9 ACTIVE-height
 rollout math.
 
+Mainnet AssumeUTXO metadata is available for the snapshot at height `2565494`.
+The snapshot base block is
+`57f2d1b39ea9e0961f50c6a20420bb478582849e50a3cdb6cbf84f98183ff482`,
+with txoutset hash
+`5440c2403752e80603a1895cfc340df5436e99513bb9a6b3e2c69dd4b1e3ab9a`
+and `nChainTx = 2986391`.
+
 Testnet is treated as a 0.25.2 feature-test/reset network. SegWit, BIP34,
 BIP65/CLTV, BIP66, and Taproot are active from height `1` on testnet so
 wallet, merged-mining, atomic-swap, Lightning, and Taproot behavior can be

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -225,14 +225,16 @@ public:
             }
         };
 
+        // BlakeBitcoin mainnet AssumeUTXO snapshot generated from a fully synced,
+        // non-pruned 25.2 node after SegWit activation.
         m_assumeutxo_data = MapAssumeutxo{
-            // Intentionally empty for BlakeBitcoin mainnet.
-            //
-            // Snapshot RPC infrastructure may be present, but do not hardcode or
-            // publish mainnet assumeutxo metadata until BlakeBitcoin's SegWit
-            // activation state and snapshot policy are finalized. With no entry
-            // here, mainnet loadtxoutset rejects snapshots instead of accepting
-            // unapproved checkpoint metadata.
+            {
+                2565494,
+                {
+                    AssumeutxoHash{uint256S("0x5440c2403752e80603a1895cfc340df5436e99513bb9a6b3e2c69dd4b1e3ab9a")},
+                    2986391,
+                },
+            },
         };
 
         // ChainTxData is used by GuessVerificationProgress for operator-facing


### PR DESCRIPTION
Register the BlakeBitcoin mainnet AssumeUTXO snapshot at height 2565494 with txoutset hash 5440c2403752e80603a1895cfc340df5436e99513bb9a6b3e2c69dd4b1e3ab9a and nChainTx 2986391.

Document the snapshot base block and txoutset metadata in README so operators can match the published 0.25.2 snapshot parameters.